### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xSML
+# Exercism Standard ML Track
 
 Exercism problems in the Standard ML programming language
 
@@ -9,5 +9,3 @@ Please see SETUP.md for instructions on how to get started solving the SML exerc
 ## Contributing Guide
 
 Please see the [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data)
-
-

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "sml",
   "language": "Standard ML",
-  "repository": "https://github.com/exercism/xsml",
+  "repository": "https://github.com/exercism/sml",
   "checklist_issue": 8,
   "active": false,
   "test_pattern": "^test_*.sml$",

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -13,7 +13,7 @@ You will need an SML interpreter to solve these problems. There are several popu
 
 #### Example:
 
-     cd ~/exercism/xsml/accumulate
+     cd ~/exercism/sml/accumulate
      poly
      Poly/ML 5.2 Release
      > use "test_accumulate.sml";


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1