### PR TITLE
nth-prime refactor

### DIFF
--- a/exercises/nth-prime/example.sml
+++ b/exercises/nth-prime/example.sml
@@ -6,7 +6,7 @@ fun next s = let
 in
     next' s
 end ;
-                 
+
 fun hd s = let
     fun hd' Nil = raise EmptyList
       | hd' (Cons(a, _)) = a
@@ -27,20 +27,21 @@ fun allPrimes n = let
     in
         (List.length (factors n)) = 1
     end
-                        
+
     fun nextPrime n = let
         val nextN = if (n mod 2) = 0 then n + 1 else n + 2
     in
         if isPrime nextN then nextN else nextPrime nextN
     end
-                          
+
 in
     Cons(n, fn () => (allPrimes (nextPrime n)))
 end ;
-                      
+
 fun nthPrime n = let
-    fun nthPrime' 0 s = hd s 
+    fun nthPrime' 0 s = hd s
       | nthPrime' n s = nthPrime' (n-1) (next s)
 in
-    nthPrime' (n-1) (allPrimes 2)
+    if n <= 0 then raise Domain
+    else nthPrime' (n-1) (allPrimes 2)
 end ;

--- a/exercises/nth-prime/nth-prime.sml
+++ b/exercises/nth-prime/nth-prime.sml
@@ -1,0 +1,2 @@
+fun nthPrime (n: int): int =
+  raise Fail "'nthPrime' has not been implemented"

--- a/exercises/nth-prime/test_nth_prime.sml
+++ b/exercises/nth-prime/test_nth_prime.sml
@@ -1,14 +1,71 @@
-use "example.sml";
+use "nth-prime.sml";
 
 val test_cases = [
-    (1, 2),
-    (2, 3),
-    (9, 23),
-    (100, 541)
+  {
+    description = "The first prime is 2",
+    input = 1,
+    expected = 2
+  },
+  {
+    description = "The second prime is 3",
+    input = 2,
+    expected = 3
+  },
+  {
+    description = "The ninth prime is 23",
+    input = 9,
+    expected = 23
+  },
+  {
+    description = "The one-hundredth prime is 541",
+    input = 1,
+    expected = 2
+  },
+  {
+    description = "The three-thousand and first prime is 27457",
+    input = 3001,
+    expected = 27457
+  }
 ];
 
-fun run_tests [] = []
-  | run_tests ((n, expected)::ts) =
-       (nthPrime n = expected) :: run_tests ts
-                                                         
-val allTestsPass = List.foldl (fn (x,y) => x andalso y) true (run_tests test_cases);
+val error_test_cases = [
+  {
+    description = "The 0th prime is not defined",
+    input = 0,
+    expected = Domain
+  },
+  {
+    description = "The -1st prime is not defined",
+    input = ~1,
+    expected = Domain
+  }
+];
+
+fun run_tests _ [] = []
+  | run_tests f (x :: xs) =
+      let
+        fun aux { description, is_correct } =
+          let
+            val expl = description ^ ": " ^
+              (if is_correct then "PASSED" else "FAILED") ^ "\n"
+          in
+            (print (expl); is_correct)
+          end
+      in
+        (aux x) :: run_tests f xs
+      end
+
+fun evaluateGoodTestCase f { description, input, expected } =
+  { description = description, is_correct = (f input) = expected }
+
+fun evaluateErrorTestCase f { description, input, expected } =
+  { description = description, is_correct = (f input handle expected => 1) = 1 }
+
+val testResults = run_tests nthPrime (List.map (evaluateGoodTestCase nthPrime) test_cases)
+  @ run_tests nthPrime (List.map (evaluateErrorTestCase nthPrime) error_test_cases);
+val passedTests = List.filter (fn x => x) testResults;
+val failedTests = List.filter (fn x => not x) testResults;
+
+if (List.length testResults) = (List.length passedTests)
+then (print "ALL TESTS PASSED")
+else (print (Int.toString (List.length failedTests) ^ " TEST(S) FAILED"));

--- a/exercises/nth-prime/test_nth_prime.sml
+++ b/exercises/nth-prime/test_nth_prime.sml
@@ -18,8 +18,8 @@ val test_cases = [
   },
   {
     description = "The one-hundredth prime is 541",
-    input = 1,
-    expected = 2
+    input = 100,
+    expected = 541
   },
   {
     description = "The three-thousand and first prime is 27457",


### PR DESCRIPTION
Implements proposal by @snahor in #32 to make sml track more consistent

Summary of changes:

Test files for nth-prime have been refactored in a consistent manner and provide output about which specific tests failed to the user without needing them to enter a REPL
All stub files now have type signatures to give the user hints about the expect input and output of each function