### PR TITLE
accumulate refactor

### DIFF
--- a/exercises/accumulate/accumulate.sml
+++ b/exercises/accumulate/accumulate.sml
@@ -1,0 +1,10 @@
+(* accumulate
+   given a list and a transformation function,
+   apply the transformation function to each list element
+   and return the results.
+
+   Caveats: an empty list cannot be transformed
+            do not use List.map from the standard basis
+*)
+fun accumulate (f: 'a -> 'b) (xs: 'a list): 'b list =
+  raise Fail "'accumulate' has not been implemented"

--- a/exercises/accumulate/example.sml
+++ b/exercises/accumulate/example.sml
@@ -1,10 +1,2 @@
-(* accumulate 
-   given a list and a transformation function, 
-   apply the transformation function to each list element
-   and return the results.
-   
-   Caveats: an empty list cannot be transformed
-            do not use List.map from the standard basis
-*)
-fun accumulate [] _      = []
-  | accumulate (x::xs) f = f x  :: accumulate xs f
+fun accumulate  _ []     = []
+  | accumulate f (x::xs) = f x :: accumulate f xs

--- a/exercises/accumulate/test_accumulate.sml
+++ b/exercises/accumulate/test_accumulate.sml
@@ -1,15 +1,58 @@
-use "example.sml";
+use "accumulate.sml";
 
 val test_cases = [
-    ( [],      (fn x => x),     []       ),
-    ( [1,2,3], (fn x => x*x),   [1,4,9]  ),
-    ( [1,2,3], (fn x => x*x*x), [1,8,27] ),
-    ( [1,2,3], (fn x => x+1),   [2,3,4]  ),
-    ( [1,2,3], (fn x => x-1),   [0,1,2]  )
+    {
+      description = "Applying a function the empty-list ([]) does nothing",
+      input       = [],
+      function    = fn x => x,
+      expected    = []
+    },
+    {
+      description = "Applying a square function to [1,2,3] produces [1,4,9]",
+      input       = [1, 2, 3],
+      function    = fn x => x*x,
+      expected    = [1, 4, 9]
+    },
+    {
+      description = "Applying a cube function to[1,2,3] produces [1,8,27]",
+      input       = [1, 2, 3],
+      function    = fn x => x*x*x,
+      expected    = [1, 8, 27]
+    },
+    {
+      description = "Applying an increment function to [1,2,3] produces [2,3,4]",
+      input       = [1, 2, 3],
+      function    = fn x => x+1,
+      expected    = [2, 3, 4]
+    },
+    {
+      description = "Applying an decrement function to [1,2,3] produces [0,1,2]",
+      input       = [1, 2, 3],
+      function    = fn x => x-1,
+      expected    = [0, 1, 2]
+    }
 ];
 
-fun run_tests [] = []
-  | run_tests ((input,function,expected)::ts) =
-       (accumulate input function = expected) :: run_tests ts
+fun run_tests _ [] = []
+  | run_tests f (x :: xs) =
+      let
+        fun aux { description, input, function, expected } =
+          let
+            val output = f function input
+            val is_correct = output = expected
+            val expl = description ^ ": " ^
+              (if is_correct then "PASSED" else "FAILED") ^ "\n"
+          in
+            (print (expl); is_correct)
+          end
+      in
+        (aux x) :: run_tests f xs
+      end
 
-val allTestsPass = List.foldl (fn (x,y) => x andalso y) true (run_tests test_cases);
+val testResults = run_tests accumulate test_cases;
+val passedTests = List.filter (fn x => x) testResults;
+val failedTests = List.filter (fn x => not x) testResults;
+
+if (List.length testResults) = (List.length passedTests)
+then (print "ALL TESTS PASSED")
+else (print (Int.toString (List.length failedTests) ^ " TEST(S) FAILED"));


### PR DESCRIPTION
Implements proposal by @snahor in #32 to make sml track more consistent

Summary of changes:

Test files for accumulate have been refactored in a consistent manner and provide output about which specific tests failed to the user without needing them to enter a REPL
All stub files now have type signatures to give the user hints about the expect input and output of each function