### PR TITLE
flatten-array refactor

### DIFF
--- a/exercises/flatten-array/example.sml
+++ b/exercises/flatten-array/example.sml
@@ -1,6 +1,6 @@
 datatype 'a nestedList =
-	  Leaf of 'a			           (* leaf *)
-	| Node of 'a nestedList list (* node *)
+	  Elem of 'a
+	| List of 'a nestedList list
 
-fun flatten (Leaf x)  = [x]
-  | flatten (Node xs) = List.concat (map flatten xs)
+fun flatten (Elem x)  = [x]
+  | flatten (List xs) = List.concat (map flatten xs)

--- a/exercises/flatten-array/flatten-array.sml
+++ b/exercises/flatten-array/flatten-array.sml
@@ -2,5 +2,5 @@ datatype 'a nestedList =
 	  Leaf of 'a			           (* leaf *)
 	| Node of 'a nestedList list (* node *)
 
-fun flatten (Leaf x)  = [x]
-  | flatten (Node xs) = List.concat (map flatten xs)
+fun flatten (xs: 'a nestedList): 'a list =
+  raise Fail "'flatten' has not been implemented"

--- a/exercises/flatten-array/flatten-array.sml
+++ b/exercises/flatten-array/flatten-array.sml
@@ -1,6 +1,6 @@
 datatype 'a nestedList =
-	  Leaf of 'a			           (* leaf *)
-	| Node of 'a nestedList list (* node *)
+	  Elem of 'a
+	| List of 'a nestedList list
 
 fun flatten (xs: 'a nestedList): 'a list =
   raise Fail "'flatten' has not been implemented"

--- a/exercises/flatten-array/test_flatten_array.sml
+++ b/exercises/flatten-array/test_flatten_array.sml
@@ -3,31 +3,31 @@ use "flatten-array.sml";
 val test_cases = [
   {
     description = "[1, [2, [], 3, [4, 5]]] flattens to [1,2,3,4,5]",
-    input = Node [
-        Leaf 1,
-        Node [
-          Leaf 2,
-          Node [],
-          Leaf 3,
-          Node [Leaf 4, Leaf 5]
+    input = List [
+        Elem 1,
+        List [
+          Elem 2,
+          List [],
+          Elem 3,
+          List [Elem 4, Elem 5]
         ]
     ],
     expected = [1, 2, 3, 4, 5]
   },
   {
     description = "[1,2,3,4,5] flattens to [1,2,3,4,5]",
-    input = Node [
-        Leaf 1,
-        Leaf 2,
-        Leaf 3,
-        Leaf 4,
-        Leaf 5
+    input = List [
+        Elem 1,
+        Elem 2,
+        Elem 3,
+        Elem 4,
+        Elem 5
     ],
     expected = [1, 2, 3, 4, 5]
   },
   {
     description = "[] flattens to []",
-    input = Node [],
+    input = List [],
     expected = []
   }
 ];

--- a/exercises/flatten-array/test_flatten_array.sml
+++ b/exercises/flatten-array/test_flatten_array.sml
@@ -1,10 +1,57 @@
-use "example.sml";
+use "flatten-array.sml";
+
 val test_cases = [
-    ((Node [Leaf 1, Node [Leaf 2, Node [], Leaf 3, Node [Leaf 4, Leaf 5]]]), [1,2,3,4,5])
+  {
+    description = "[1, [2, [], 3, [4, 5]]] flattens to [1,2,3,4,5]",
+    input = Node [
+        Leaf 1,
+        Node [
+          Leaf 2,
+          Node [],
+          Leaf 3,
+          Node [Leaf 4, Leaf 5]
+        ]
+    ],
+    expected = [1, 2, 3, 4, 5]
+  },
+  {
+    description = "[1,2,3,4,5] flattens to [1,2,3,4,5]",
+    input = Node [
+        Leaf 1,
+        Leaf 2,
+        Leaf 3,
+        Leaf 4,
+        Leaf 5
+    ],
+    expected = [1, 2, 3, 4, 5]
+  },
+  {
+    description = "[] flattens to []",
+    input = Node [],
+    expected = []
+  }
 ];
 
-fun run_tests [] = []
-  | run_tests ((input,expected)::ts) =
-       (flatten input = expected) :: run_tests ts
+fun run_tests _ [] = []
+  | run_tests f (x :: xs) =
+      let
+        fun aux { description, input, expected } =
+          let
+            val output = f input
+            val is_correct = output = expected
+            val expl = description ^ ": " ^
+              (if is_correct then "PASSED" else "FAILED") ^ "\n"
+          in
+            (print (expl); is_correct)
+          end
+      in
+        (aux x) :: run_tests f xs
+      end
 
-val allTestsPass = List.foldl (fn (x,y) => x andalso y) true (run_tests test_cases);
+val testResults = run_tests flatten test_cases;
+val passedTests = List.filter (fn x => x) testResults;
+val failedTests = List.filter (fn x => not x) testResults;
+
+if (List.length testResults) = (List.length passedTests)
+then (print "ALL TESTS PASSED")
+else (print (Int.toString (List.length failedTests) ^ " TEST(S) FAILED"));


### PR DESCRIPTION
Implements proposal by @snahor in #32 to make sml track more consistent

Summary of changes:

Test files for flatten-array have been refactored in a consistent manner and provide output about which specific tests failed to the user without needing them to enter a REPL
All stub files now have type signatures to give the user hints about the expect input and output of each function