### PR TITLE
hamming refactor

### DIFF
--- a/exercises/hamming/hamming.sml
+++ b/exercises/hamming/hamming.sml
@@ -1,0 +1,3 @@
+exception NonEqualLengthStringsFound;
+fun hamming (s1: string, s2: string): int =
+  raise Fail "'hamming' has not been implemented"


### PR DESCRIPTION
Implements proposal by @snahor in #32 to make sml track more consistent

Summary of changes:

Test files for hamming have been refactored in a consistent manner and provide output about which specific tests failed to the user without needing them to enter a REPL
All stub files now have type signatures to give the user hints about the expect input and output of each function