### PR TITLE
Fix test pattern in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "language": "Standard ML",
   "checklist_issue": 8,
   "active": false,
-  "test_pattern": "^test_*.sml$",
+  "test_pattern": "test_.*[.]sml$",
   "exercises": [
     {
       "uuid": "333c2cb9-f03c-473c-9eeb-096072a321b2",


### PR DESCRIPTION
The website isn't detecting the test suite:
http://exercism.io/exercises/sml/raindrops/test-suite

It turns out the asterisk in the `config.json`'s `test_pattern` was operating on the underscore, rather than on a dot.

In addition, the detection is made against paths, not just the basename, so I had to take off the anchor at the beginning of the pattern.

We could add a character group that matches path separators, but I think
it's probably fine to just leave the start a bit ambiguous.
