### PR TITLE
Exercise generator and testlib

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -1,0 +1,275 @@
+import json
+import re
+import shutil
+
+from pathlib import Path
+from collections import OrderedDict
+from urllib.request import urlopen, HTTPError
+from http import HTTPStatus
+
+
+canonical_data_url = 'https://raw.githubusercontent.com/exercism' + \
+                     '/problem-specifications/master' + \
+                     '/exercises/%s/canonical-data.json'
+
+
+def fetch(exercise):
+    try:
+        with urlopen(canonical_data_url % exercise) as response:
+            return json.loads(response.read().decode('utf8'))
+    except HTTPError as e:
+        if e.status == HTTPStatus.NOT_FOUND.value:
+            msg = "Exercise '%s' doesn't exist." % exercise
+        else:
+            msg = 'Unexpected error, please try again later.'
+        raise Exception(msg)
+
+
+def load(exercise):
+    root = Path(__file__).absolute().parent.parent.parent
+    path = root / 'problem-specifications/exercises'
+    with (path / exercise / 'canonical-data.json').open() as f:
+        return json.loads(f.read())
+
+
+def indent(n, s):
+    return s.rjust(len(s) + n, ' ')
+
+
+def camelize(s):
+    return re.sub('[-_](\w)', lambda x: x.group(1).upper(), s)
+
+
+def sml_type(value):
+    if value is None:
+        return 'option'
+    if isinstance(value, list):
+        if not value:
+            return "'a list"
+        s = {sml_type(v)
+             for v in value
+             # }
+             if not (isinstance(v, list) and not v)}
+        s.discard('exn')
+        if not s or len(s) > 2:
+            raise Exception('Failed to infer a proper type')
+        if len(s) == 1:
+            return '%s list' % s.pop()
+        if 'option' not in s:
+            raise Exception('Failed to infer a proper type, got multiple types', value, s)
+        s.remove('option')
+        return '%s option list' % s.pop()
+    if isinstance(value, dict):
+        if 'error' in value:
+            return 'exn'
+        return '{%s}' % ', '.join(
+            '%s: %s' % (key, sml_type(value[key]))
+            for key in sorted(value.keys())
+        )
+    types = {int: 'int', str: 'string', float: 'real', bool: 'bool'}
+    return types[type(value)]
+
+
+def sml_value(value, smltype=''):
+    if value is None:
+        return 'NONE'
+    _value = None
+    if isinstance(value, str):
+        _value = json.dumps(value)
+    if isinstance(value, bool):
+        _value = str(value).lower()
+    if isinstance(value, (int, float)):
+        if value < 0:
+            _value = '~%s' % -value
+        else:
+            _value = str(value)
+    if isinstance(value, list):
+        _value = '[%s]' % ', '.join(sml_value(v) for v in value)
+    if isinstance(value, dict):
+        if 'error' in value:
+            return 'Fail "%s"' % value['error']
+        _value = '{%s}' % ', '.join('%s = %s' % (k, sml_value(v))
+                                  for k, v in value.items())
+    return _value if 'option' not in smltype else ('SOME ' + _value)
+
+
+def get_fn_args(case):
+    ignored_keys = {'property', 'expected', 'description', 'comments'}
+    return OrderedDict(
+        (k, case[k])
+        for k in sorted(case.keys())
+        if k not in ignored_keys
+    )
+
+
+def extract_signatures(data):
+    funcs = OrderedDict()
+    exercise = data['exercise']
+    ignored_keys = {'property', 'expected', 'description', 'comments'}
+
+    def type_aux(values):
+        s = {sml_type(val) for val in values}
+        if len(s) == 1:
+            return s.pop()
+        if len(s) == 2 and 'option' in s:
+            s.remove('option')
+            return '%s option' % s.pop()
+        raise Exception('Failed to infer a proper type, can not unify different types: %s' % s)
+
+    def signature(xs):
+        output = []
+        args = OrderedDict()
+        for x in xs:
+            output.append(x['output'])
+            for arg, val in x['args'].items():
+                args.setdefault(arg, []).append(val)
+        return {
+            'args': OrderedDict((arg, type_aux(vals)) for arg, vals in args.items()),
+            'output': type_aux(output),
+        }
+
+    def collect(cases):
+        for case in cases:
+            if 'cases' in case:
+                collect(case['cases'])
+            else:
+                # assumes there's at least one test with non "nullish" vars
+                fn = camelize(case.get('property', exercise))
+                if sml_type(case['expected']) == 'exn':
+                    continue
+                args = get_fn_args(case)
+                if not all(args.values()) or sml_type(case['expected']) == "'a list":# or not case['expected']:
+                    continue
+                funcs.setdefault(fn, []).append({
+                    'args': args,
+                    'output': case['expected']
+                })
+
+    collect(data['cases'])
+    return {fn: signature(funcs[fn]) for fn in funcs}
+
+
+def expectation(signature, fn, args, expected):
+    tmpl = '(fn _ => %s |> Expect.%s)'
+    output = sml_value(expected, signature['output'])
+    invocation = '%s (%s)' % (
+        fn,
+        ', '.join((
+            sml_value(val, signature['args'][arg])
+            for arg, val in args.items())
+        )
+    )
+    if sml_type(expected) == 'exn':
+        return tmpl % (
+            '(fn _ => %s)' % invocation,
+            'error (%s)' % output
+        )
+    if signature['output'] == 'bool':
+        return tmpl % (
+            invocation,
+            'truthy' if expected else 'falsy'
+        )
+    if signature['output'] == 'real':
+        return tmpl % (
+            invocation,
+            'nearTo %s' % output
+        )
+    return tmpl % (
+        invocation,
+        ('equalTo (%s)' if 'SOME ' in output else 'equalTo %s') % output
+    )
+
+
+def generate_test_content(data, signature):
+    exercise = data['exercise']
+
+    def fmt(case, depth=0):
+        if 'property' not in  case:
+            print('WARNING: property not found using exercise name as function name')
+        fn = camelize(case.get('property', exercise))
+        expected = case['expected']
+        args = get_fn_args(case)
+        return '\n'.join((
+            indent(depth, 'test "%s"' % case.get('description', fn)),
+            indent(depth + 2, expectation(signature[fn], fn, args, expected))
+        ))
+
+    def traverse(cases, depth=0):
+        acc = []
+        for case in cases:
+            if 'cases' in case:
+                acc.append('\n'.join((
+                    indent(depth * 2, 'describe "%s" [' % case['description']),
+                    ',\n\n'.join(traverse(case['cases'], depth + 1)),
+                    indent(depth * 2, ']')
+                )))
+            else:
+                acc.append(fmt(case, depth * 2))
+        return acc
+
+    return '\n'.join([
+        '(* version %s *)' % data['version'],
+        '',
+        'use "%s.sml";' % data['exercise'],
+        'use "testlib.sml";',
+        '',
+        'infixr |>',
+        'fun x |> f = f x',
+        '',
+        'val testsuite =',
+        '  describe "%s" [' % data['exercise'],
+        ',\n\n'.join(traverse(data['cases'], depth=2)),
+        '  ]',
+        '',
+        'val _ = Test.run testsuite'
+    ])
+
+
+def generate_exercise_content(signatures):
+    def fmt(args):
+        return ', '.join('%s: %s' % (name, value)
+                        for name, value in args.items())
+
+    return '\n\n'.join(
+        'fun {0} ({1}): {2} =\n'
+        '  raise Fail "\'{0}\' is not implemented"'.format(
+            fn,
+            fmt(signature['args']),
+            signature['output']
+        )
+        for fn, signature in signatures.items()
+    )
+
+
+def write(path, content):
+    with path.open('w') as f:
+        f.write(content)
+
+
+def generate(exercise):
+    root = Path(__file__).parent.parent.absolute()
+    path = root / 'exercises' / exercise
+    if not path.exists():
+        path.mkdir()
+    data = fetch(exercise)
+    signatures = extract_signatures(data)
+    write(path / 'test.sml', generate_test_content(data, signatures))
+    content = generate_exercise_content(signatures)
+    write(path / ('%s.sml' % exercise), content)
+    write(path / 'example.sml', content)
+    shutil.copyfile(
+        (root / 'lib/testlib.sml').as_posix(),
+        (path / 'testlib.sml').as_posix()
+    )
+
+
+if __name__ == '__main__':
+    import sys
+
+    for exercise in sys.argv[1:]:
+        try:
+            generate(exercise)
+        except FileNotFoundError:
+            print('[%s]: canonical-data.json not found' % exercise)
+        except Exception as e:
+            print('[%s]: %s' % (exercise, e))

--- a/bin/generate
+++ b/bin/generate
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import json
 import re
 import shutil

--- a/lib/testlib.sml
+++ b/lib/testlib.sml
@@ -1,0 +1,159 @@
+structure Expect =
+struct
+  datatype expectation = Pass | Fail of string * string
+
+  local
+    fun failEq b a =
+      Fail ("Expected: " ^ b, "Got: " ^ a)
+    
+    fun failExn b a =
+      Fail ("Expected: " ^ b, "Raised: " ^ a)
+
+    fun exnName (e: exn): string = General.exnName e
+  in
+    fun truthy a =
+      if a
+      then Pass
+      else failEq "true" "false"
+
+    fun falsy a =
+      if a
+      then failEq "false" "true"
+      else Pass
+
+    fun equalTo b a = 
+      if a = b
+      then Pass
+      else failEq (PolyML.makestring b) (PolyML.makestring a)
+
+    fun nearTo b a =
+      if Real.== (a, b)
+      then Pass
+      else failEq (Real.toString b) (Real.toString a)
+
+    fun anyError f =
+      (
+        f ();
+        failExn "an exception" "Nothing"
+      ) handle _ => Pass
+
+    fun error e f =
+      (
+        f ();
+        failExn (exnName e) "Nothing"
+      ) handle e' => if exnMessage e' = exnMessage e
+                     then Pass
+                     else failExn (exnMessage e) (exnMessage e')
+  end
+end
+
+structure TermColor =
+struct
+  datatype color = Red | Green | Yellow | Normal
+
+  fun f Red    = "\027[31m"
+    | f Green  = "\027[32m"
+    | f Yellow = "\027[33m"
+    | f Normal = "\027[0m"
+
+  fun colorize color s = (f color) ^ s ^ (f Normal)
+
+  val redit = colorize Red
+
+  val greenit = colorize Green
+
+  val yellowit = colorize Yellow
+end
+
+structure Test =
+struct
+  datatype testnode = TestGroup of string * testnode list
+                    | Test of string * (unit -> Expect.expectation)
+
+  local
+    datatype evaluation = Success of string
+                        | Failure of string * string * string
+                        | Error of string * string
+
+    fun indent n s = (implode (List.tabulate (n, fn _ => #" "))) ^ s
+
+    fun fmt indentlvl ev =
+      let
+        val check = TermColor.greenit "\226\156\148 " (* ✔ *)
+        val cross = TermColor.redit "\226\156\150 "   (* ✖ *)
+        val indentlvl = indentlvl * 2
+      in
+      case ev of
+        Success descr => indent indentlvl (check ^ descr)
+      | Failure (descr, exp, got) =>
+          String.concatWith "\n" [indent indentlvl (cross ^ descr),
+                                  indent (indentlvl + 2) exp,
+                                  indent (indentlvl + 2) got]
+      | Error (descr, reason) =>
+          String.concatWith "\n" [indent indentlvl (cross ^ descr),
+                                  indent (indentlvl + 2) (TermColor.redit reason)]
+      end
+
+    fun eval (TestGroup _) = raise Fail "Only a 'Test' can be evaluated"
+      | eval (Test (descr, thunk)) =
+          (
+            case thunk () of
+              Expect.Pass   => ((1, 0, 0), Success descr)
+            | Expect.Fail (s, s') => ((0, 1, 0), Failure (descr, s, s'))
+          )
+          handle e => ((0, 0, 1), Error (descr, "Unexpected error: " ^ exnMessage e))
+
+    fun flatten depth testnode =
+      let
+        fun sum (x, y, z) (a, b, c) = (x + a, y + b, z + c)
+
+        fun aux (t, (counter, acc)) =
+          let
+            val (counter', texts) = flatten (depth + 1) t
+          in
+            (sum counter' counter, texts :: acc)
+          end
+      in
+        case testnode of
+          TestGroup (descr, ts) =>
+            let
+              val (counter, texts) = foldr aux ((0, 0, 0), []) ts
+            in
+              (counter, (indent (depth * 2) descr) :: List.concat texts)
+            end
+        | Test _ =>
+            let
+              val (counter, evaluation) = eval testnode
+            in
+              (counter, [fmt depth evaluation])
+            end
+      end
+    
+    fun println s = print (s ^ "\n")
+  in
+    fun run suite =
+      let
+        val ((succeeded, failed, errored), texts) = flatten 0 suite
+
+        val summary = String.concatWith ", " [
+          TermColor.greenit ((Int.toString succeeded) ^ " passed"),
+          TermColor.redit ((Int.toString failed) ^ " failed"),
+          TermColor.redit ((Int.toString errored) ^ " errored"),
+          (Int.toString (succeeded + failed + errored)) ^ " total"
+        ]
+        
+        val status = if failed = 0 andalso errored = 0
+                     then OS.Process.success
+                     else OS.Process.failure
+
+      in
+        List.app println texts;
+        println "";
+        println ("Tests: " ^ summary);
+        OS.Process.exit status
+      end
+  end
+end
+
+fun describe description tests = Test.TestGroup (description, tests)
+fun test description thunk = Test.Test (description, thunk)


### PR DESCRIPTION
REF: #46, #47 

## Usage:
```
bin/generate <exercise>
```
**Note:** It will fail with some exercises. Reasons: type mismatch, for instance in `wordy` the expected value is a boolean, but some test cases have `-1`.

It will generate:
- `exercises/{exercise}/{exercise}.sml`
- `exercises/{exercise}/test.sml`
- `exercises/{exercise}/testlib.sml`
- `exercises/{exercise}/example.sml`

### `testlib.sml`

```sml
structure Expect:
  sig
    val anyError: (unit -> 'a) -> expectation
    val equalTo: ''a -> ''a -> expectation
    val error: exn -> (unit -> 'a) -> expectation
    datatype expectation = Fail of string * string | Pass
    val falsy: bool -> expectation
    val nearTo: real -> real -> expectation
    val truthy: bool -> expectation
  end
structure Test:
  sig
    val run: testnode -> 'a
    datatype testnode =
        Test of string * (unit -> Expect.expectation)
      | TestGroup of string * testnode list
  end
val describe = fn: string -> Test.testnode list -> Test.testnode
val test = fn: string -> (unit -> Expect.expectation) -> Test.testnode
```
#### Example

```sml
(* test.sml *)
use "hello-world.sml";
use "testlib.sml";

infixr |>
fun x |> f = f x

val testsuite =
  describe "hello-world" [
    test "Say Hi!"
      (fn _ => hello () |> Expect.equalTo "Hello, World!")
  ]

val _ = Test.run testsuite
```

Using `testlib.sml` will generate an output similar to this:
[![asciicast](https://asciinema.org/a/LzGJ8BzLJ2P86zUpVUUbqqgW7.png)](https://asciinema.org/a/LzGJ8BzLJ2P86zUpVUUbqqgW7)