### PR TITLE
Update generator, flatten-array & nth-prime

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,30 @@ bin/generate {{ slug }}
 
 It will create the exercise directory, test and stub files.
 
+### Generator
+
+```
+usage: generate [-h] [--force] [--test-only] [--stub-only] [--example-only]
+                exercises [exercises ...]
+
+positional arguments:
+  exercises
+
+optional arguments:
+  -h, --help      show this help message and exit
+  --force         Type inference will be disabled and "string" will be
+                  assumed. Test cases will need to be modified to match the
+                  right data type.
+  --test-only     Generate only "test.sml"
+  --stub-only     Generate only "<exercise>.sml"
+  --example-only  Generate only "example.sml"
+```
+
 **Note:**
 - You need Python 3.5+.
 - It may fail with some exercises. Reasons:
   - `canonical-data.json` does not exist
-  - type mismatch
+  - type mismatch (in these situation you can use `--force` option)
 
 In those cases you will have to create the files manually. `testlib.sml` can be copied from `lib/testlib.sml`. When in doubt, feel free to open an issue.
 

--- a/bin/generate
+++ b/bin/generate
@@ -42,7 +42,9 @@ def camelize(s):
     return re.sub('[-_](\w)', lambda x: x.group(1).upper(), s)
 
 
-def sml_type(value):
+def sml_type(value, force=False):
+    if force:
+        return 'string'
     if value is None:
         return 'option'
     if isinstance(value, list):
@@ -72,7 +74,9 @@ def sml_type(value):
     return types[type(value)]
 
 
-def sml_value(value, smltype=''):
+def sml_value(value, smltype='', force=False):
+    if force:
+        return json.dumps(value)
     if value is None:
         return 'NONE'
     _value = None
@@ -104,12 +108,12 @@ def get_fn_args(case):
     )
 
 
-def extract_signatures(data):
+def extract_signatures(data, force=False):
     funcs = OrderedDict()
     exercise = data['exercise']
 
     def type_aux(values):
-        s = {sml_type(val) for val in values}
+        s = {sml_type(val, force=force) for val in values}
         if len(s) == 1:
             return s.pop()
         if len(s) == 2 and 'option' in s:
@@ -136,10 +140,10 @@ def extract_signatures(data):
             else:
                 # assumes there's at least one test with non "nullish" vars
                 fn = camelize(case.get('property', exercise))
-                if sml_type(case['expected']) == 'exn':
+                if sml_type(case['expected'], force=force) == 'exn':
                     continue
                 args = get_fn_args(case)
-                if not all(args.values()) or sml_type(case['expected']) == "'a list":# or not case['expected']:
+                if not all(args.values()) or sml_type(case['expected'], force=force) == "'a list":# or not case['expected']:
                     continue
                 funcs.setdefault(fn, []).append({
                     'args': args,
@@ -150,17 +154,17 @@ def extract_signatures(data):
     return {fn: signature(funcs[fn]) for fn in funcs}
 
 
-def expectation(signature, fn, args, expected):
+def expectation(signature, fn, args, expected, force=False):
     tmpl = '(fn _ => %s |> Expect.%s)'
-    output = sml_value(expected, signature['output'])
+    output = sml_value(expected, signature['output'], force=force)
     invocation = '%s (%s)' % (
         fn,
         ', '.join((
-            sml_value(val, signature['args'][arg])
+            sml_value(val, signature['args'][arg], force=force)
             for arg, val in args.items())
         )
     )
-    if sml_type(expected) == 'exn':
+    if sml_type(expected, force=force) == 'exn':
         return tmpl % (
             '(fn _ => %s)' % invocation,
             'error (%s)' % output
@@ -181,7 +185,7 @@ def expectation(signature, fn, args, expected):
     )
 
 
-def generate_test_content(data, signature):
+def generate_test_content(data, signature, force=False):
     exercise = data['exercise']
 
     def fmt(case, depth=0):
@@ -192,7 +196,7 @@ def generate_test_content(data, signature):
         args = get_fn_args(case)
         return '\n'.join((
             indent(depth, 'test "%s"' % case.get('description', fn)),
-            indent(depth + 2, expectation(signature[fn], fn, args, expected))
+            indent(depth + 2, expectation(signature[fn], fn, args, expected, force=force))
         ))
 
     def traverse(cases, depth=0):
@@ -247,17 +251,33 @@ def write(path, content):
         f.write(content)
 
 
-def generate(exercise):
+# flags
+TEST = 1
+STUB = 2
+EXAMPLE = 4
+FLAGS = TEST | STUB | EXAMPLE
+
+
+def generate(exercise, flags, force=False):
     root = Path(__file__).parent.parent.absolute()
     path = root / 'exercises' / exercise
+
     if not path.exists():
         path.mkdir()
+
     data = fetch(exercise)
-    signatures = extract_signatures(data)
-    write(path / 'test.sml', generate_test_content(data, signatures))
+    signatures = extract_signatures(data, force=force)
     content = generate_exercise_content(signatures)
-    write(path / ('%s.sml' % exercise), content)
-    write(path / 'example.sml', content)
+
+    if flags & TEST:
+        write(path / 'test.sml', generate_test_content(data, signatures, force=force))
+
+    if flags & STUB:
+        write(path / ('%s.sml' % exercise), content)
+
+    if flags & EXAMPLE:
+        write(path / 'example.sml', content)
+
     shutil.copyfile(
         (root / 'lib/testlib.sml').as_posix(),
         (path / 'testlib.sml').as_posix()
@@ -265,11 +285,45 @@ def generate(exercise):
 
 
 if __name__ == '__main__':
-    import sys
+    import argparse
 
-    for exercise in sys.argv[1:]:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('exercises', nargs='+')
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help=(
+            'Type inference will be disabled and "string" will be assumed. ' +
+            'Test cases will need to be modified to match the right data type.'
+        )
+    )
+    parser.add_argument(
+        '--test-only',
+        action='store_true',
+        help='Generate only "test.sml"'
+    )
+    parser.add_argument(
+        '--stub-only',
+        action='store_true',
+        help='Generate only "<exercise>.sml"'
+    )
+    parser.add_argument(
+        '--example-only',
+        action='store_true',
+        help='Generate only "example.sml"'
+    )
+    args = parser.parse_args()
+
+    for exercise in args.exercises:
         try:
-            generate(exercise)
+            flags = 0
+            if args.test_only:
+                flags |= ~(STUB | EXAMPLE)
+            if args.example_only:
+                flags |= ~(STUB | TEST)
+            if args.stub_only:
+                flags |= ~(TEST | EXAMPLE)
+            generate(exercise, force=args.force, flags=flags or FLAGS)
         except FileNotFoundError:
             print('[%s]: canonical-data.json not found' % exercise)
         except Exception as e:

--- a/exercises/flatten-array/HINTS.md
+++ b/exercises/flatten-array/HINTS.md
@@ -1,0 +1,8 @@
+## Hints
+
+You can think of this data structure as a [`Rose Tree`](https://en.wikipedia.org/wiki/Rose_tree). You are given a data type `'a tree` that represents this data structure.
+
+**Notes**
+- For this exercise `Empty` represents `null`
+- The nested list is represented by `List [...]`.
+- The input example is represented by `List [Elem 1, List [Elem 2, Elem 3, Empty, Elem 4], List [Empty], Elem 5]`

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -3,26 +3,51 @@
 Take a nested list and return a single flattened list with all values except nil/null.
 
 The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
- 
+
 For Example
 
 input: [1,[2,3,null,4],[null],5]
 
 output: [1,2,3,4,5]
 
+## Hints
+
+You can think of this data structure as a [`Rose Tree`](https://en.wikipedia.org/wiki/Rose_tree). You are given a data type `'a tree` that represents this data structure.
+
+**Notes**
+- For this exercise `Empty` represents `null`
+- The nested list is represented by `List [...]`.
+- The input example is represented by `List [Elem 1, List [Elem 2, Elem 3, Empty, Elem 4], List [Empty], Elem 5]`
+
+
+## Loading your exercise implementation in PolyML
+
+```
+$ poly --use {exercise}.sml
+```
+
+Or:
+
+```
+$ poly
+> use "{exercise}.sml";
+```
+
+**Note:** You have to replace {exercise}.
 
 ## Running the tests
 
-Even though there are multiple implementations, we encourage to use Poly/ML.
-
 ```
-$ poly -q < test_{ exercise }.sml
+$ poly -q --use test.sml
 ```
 
-If you want to start an interactive session:
-```
-$ poly --use test_{ exercise }.sml
-```
+## Feedback, Issues, Pull Requests
+
+The [exercism/sml](https://github.com/exercism/sml) repository on
+GitHub is the home for all of the Standard ML exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue. We'll do our best to help you!
 
 ## Source
 

--- a/exercises/flatten-array/example.sml
+++ b/exercises/flatten-array/example.sml
@@ -1,6 +1,5 @@
-datatype 'a nestedList =
-	  Elem of 'a
-	| List of 'a nestedList list
+datatype 'a tree = Empty | Elem of 'a | List of 'a tree list
 
-fun flatten (Elem x)  = [x]
+fun flatten Empty     = []
+  | flatten (Elem x)  = [x]
   | flatten (List xs) = List.concat (map flatten xs)

--- a/exercises/flatten-array/flatten-array.sml
+++ b/exercises/flatten-array/flatten-array.sml
@@ -1,6 +1,5 @@
-datatype 'a nestedList =
-	  Elem of 'a
-	| List of 'a nestedList list
+(* Rose tree *)
+datatype 'a tree = Empty | Elem of 'a | List of 'a tree list
 
-fun flatten (xs: 'a nestedList): 'a list =
+fun flatten (xs: 'a tree): 'a list =
   raise Fail "'flatten' has not been implemented"

--- a/exercises/flatten-array/test.sml
+++ b/exercises/flatten-array/test.sml
@@ -1,57 +1,81 @@
+(* version 1.1.0 *)
+
+use "testlib.sml";
 use "flatten-array.sml";
 
-val test_cases = [
-  {
-    description = "[1, [2, [], 3, [4, 5]]] flattens to [1,2,3,4,5]",
-    input = List [
-        Elem 1,
-        List [
-          Elem 2,
-          List [],
-          Elem 3,
-          List [Elem 4, Elem 5]
-        ]
-    ],
-    expected = [1, 2, 3, 4, 5]
-  },
-  {
-    description = "[1,2,3,4,5] flattens to [1,2,3,4,5]",
-    input = List [
-        Elem 1,
-        Elem 2,
-        Elem 3,
-        Elem 4,
-        Elem 5
-    ],
-    expected = [1, 2, 3, 4, 5]
-  },
-  {
-    description = "[] flattens to []",
-    input = List [],
-    expected = []
-  }
-];
+infixr |>
+fun x |> f = f x
 
-fun run_tests _ [] = []
-  | run_tests f (x :: xs) =
-      let
-        fun aux { description, input, expected } =
-          let
-            val output = f input
-            val is_correct = output = expected
-            val expl = description ^ ": " ^
-              (if is_correct then "PASSED" else "FAILED") ^ "\n"
-          in
-            (print (expl); is_correct)
-          end
+val testsuite =
+  describe "flatten-array" [
+    test "no nesting"
+      (fn _ => let
+        val nested = List [Elem 0, Elem 1, Elem 2]
       in
-        (aux x) :: run_tests f xs
-      end
+        flatten nested |> Expect.equalTo [0, 1, 2]
+      end),
 
-val testResults = run_tests flatten test_cases;
-val passedTests = List.filter (fn x => x) testResults;
-val failedTests = List.filter (fn x => not x) testResults;
+    test "flattens array with just integers present"
+      (fn _ => let
+        val nested = List [Elem 1,
+                           List [Elem 2, Elem 3, Elem 4, Elem 5, Elem 6, Elem 7],
+                           Elem 8]
+      in
+        flatten nested |> Expect.equalTo [1, 2, 3, 4, 5, 6, 7, 8]
+      end),
 
-if (List.length testResults) = (List.length passedTests)
-then (print "ALL TESTS PASSED")
-else (print (Int.toString (List.length failedTests) ^ " TEST(S) FAILED"));
+    test "5 level nesting"
+      (fn _ => let
+        val nested = List [Elem 0,
+                           Elem 2,
+                           List [List [Elem 2, Elem 3],
+                                 Elem 8,
+                                 Elem 100,
+                                 Elem 4,
+                                 List [List [List [Elem 50]]]],
+                           Elem (~2)]
+      in
+        flatten nested |> Expect.equalTo [0, 2, 2, 3, 8, 100, 4, 50, ~2]
+      end),
+
+    test "6 level nesting"
+      (fn _ => let
+        val nested = List [Elem 1,
+                           List [Elem 2,
+                                 List [List [Elem 3]],
+                                 List [Elem 4, List [List [Elem 5]]],
+                                 Elem 6,
+                                 Elem 7],
+                           Elem 8]
+      in
+        flatten nested |> Expect.equalTo [1, 2, 3, 4, 5, 6, 7, 8]
+      end),
+
+    test "6 level nest list with Empty values"
+      (fn _ => let
+        val nested = List [Elem 0,
+                           Elem 2,
+                           List [List [Elem 2, Elem 3],
+                                 Elem 8,
+                                 List [List [Elem 100]],
+                                 Empty,
+                                 List [List [Empty]]],
+                           Elem (~2)]
+      in
+        flatten nested |> Expect.equalTo [0, 2, 2, 3, 8, 100, ~2]
+      end),
+
+    test "all values in nested list are Empty"
+      (fn _ => let
+         val nested = List [Empty,
+                            List [List [List [Empty]]],
+                            Empty,
+                            Empty,
+                            List [List [Empty, Empty], Empty],
+                            Empty]
+       in
+         flatten nested |> Expect.equalTo []
+       end)
+  ]
+
+val _ = Test.run testsuite

--- a/exercises/flatten-array/testlib.sml
+++ b/exercises/flatten-array/testlib.sml
@@ -1,0 +1,159 @@
+structure Expect =
+struct
+  datatype expectation = Pass | Fail of string * string
+
+  local
+    fun failEq b a =
+      Fail ("Expected: " ^ b, "Got: " ^ a)
+    
+    fun failExn b a =
+      Fail ("Expected: " ^ b, "Raised: " ^ a)
+
+    fun exnName (e: exn): string = General.exnName e
+  in
+    fun truthy a =
+      if a
+      then Pass
+      else failEq "true" "false"
+
+    fun falsy a =
+      if a
+      then failEq "false" "true"
+      else Pass
+
+    fun equalTo b a = 
+      if a = b
+      then Pass
+      else failEq (PolyML.makestring b) (PolyML.makestring a)
+
+    fun nearTo b a =
+      if Real.== (a, b)
+      then Pass
+      else failEq (Real.toString b) (Real.toString a)
+
+    fun anyError f =
+      (
+        f ();
+        failExn "an exception" "Nothing"
+      ) handle _ => Pass
+
+    fun error e f =
+      (
+        f ();
+        failExn (exnName e) "Nothing"
+      ) handle e' => if exnMessage e' = exnMessage e
+                     then Pass
+                     else failExn (exnMessage e) (exnMessage e')
+  end
+end
+
+structure TermColor =
+struct
+  datatype color = Red | Green | Yellow | Normal
+
+  fun f Red    = "\027[31m"
+    | f Green  = "\027[32m"
+    | f Yellow = "\027[33m"
+    | f Normal = "\027[0m"
+
+  fun colorize color s = (f color) ^ s ^ (f Normal)
+
+  val redit = colorize Red
+
+  val greenit = colorize Green
+
+  val yellowit = colorize Yellow
+end
+
+structure Test =
+struct
+  datatype testnode = TestGroup of string * testnode list
+                    | Test of string * (unit -> Expect.expectation)
+
+  local
+    datatype evaluation = Success of string
+                        | Failure of string * string * string
+                        | Error of string * string
+
+    fun indent n s = (implode (List.tabulate (n, fn _ => #" "))) ^ s
+
+    fun fmt indentlvl ev =
+      let
+        val check = TermColor.greenit "\226\156\148 " (* ✔ *)
+        val cross = TermColor.redit "\226\156\150 "   (* ✖ *)
+        val indentlvl = indentlvl * 2
+      in
+      case ev of
+        Success descr => indent indentlvl (check ^ descr)
+      | Failure (descr, exp, got) =>
+          String.concatWith "\n" [indent indentlvl (cross ^ descr),
+                                  indent (indentlvl + 2) exp,
+                                  indent (indentlvl + 2) got]
+      | Error (descr, reason) =>
+          String.concatWith "\n" [indent indentlvl (cross ^ descr),
+                                  indent (indentlvl + 2) (TermColor.redit reason)]
+      end
+
+    fun eval (TestGroup _) = raise Fail "Only a 'Test' can be evaluated"
+      | eval (Test (descr, thunk)) =
+          (
+            case thunk () of
+              Expect.Pass   => ((1, 0, 0), Success descr)
+            | Expect.Fail (s, s') => ((0, 1, 0), Failure (descr, s, s'))
+          )
+          handle e => ((0, 0, 1), Error (descr, "Unexpected error: " ^ exnMessage e))
+
+    fun flatten depth testnode =
+      let
+        fun sum (x, y, z) (a, b, c) = (x + a, y + b, z + c)
+
+        fun aux (t, (counter, acc)) =
+          let
+            val (counter', texts) = flatten (depth + 1) t
+          in
+            (sum counter' counter, texts :: acc)
+          end
+      in
+        case testnode of
+          TestGroup (descr, ts) =>
+            let
+              val (counter, texts) = foldr aux ((0, 0, 0), []) ts
+            in
+              (counter, (indent (depth * 2) descr) :: List.concat texts)
+            end
+        | Test _ =>
+            let
+              val (counter, evaluation) = eval testnode
+            in
+              (counter, [fmt depth evaluation])
+            end
+      end
+    
+    fun println s = print (s ^ "\n")
+  in
+    fun run suite =
+      let
+        val ((succeeded, failed, errored), texts) = flatten 0 suite
+
+        val summary = String.concatWith ", " [
+          TermColor.greenit ((Int.toString succeeded) ^ " passed"),
+          TermColor.redit ((Int.toString failed) ^ " failed"),
+          TermColor.redit ((Int.toString errored) ^ " errored"),
+          (Int.toString (succeeded + failed + errored)) ^ " total"
+        ]
+        
+        val status = if failed = 0 andalso errored = 0
+                     then OS.Process.success
+                     else OS.Process.failure
+
+      in
+        List.app println texts;
+        println "";
+        println ("Tests: " ^ summary);
+        OS.Process.exit status
+      end
+  end
+end
+
+fun describe description tests = Test.TestGroup (description, tests)
+fun test description thunk = Test.Test (description, thunk)

--- a/exercises/nth-prime/HINTS.md
+++ b/exercises/nth-prime/HINTS.md
@@ -1,0 +1,9 @@
+## Hints
+
+If the argument is not less than `1` raise the exception [`Domain`](http://sml-family.org/Basis/general.html#SIG:GENERAL.Domain:EXN).
+
+Some of these concepts may be helpful:
+
+- [Lazy evaluation](https://en.wikipedia.org/wiki/Lazy_evaluation)
+- Sieving (for instance [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
+- Primality by [trial division](https://en.wikipedia.org/wiki/Trial_divisio://en.wikipedia.org/wiki/Trial_division)

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -8,18 +8,45 @@ the 6th prime is 13.
 If your language provides methods in the standard library to deal with prime
 numbers, pretend they don't exist and implement them yourself.
 
+## Hints
+
+If the argument is not less than `1` raise the exception [`Domain`](http://sml-family.org/Basis/general.html#SIG:GENERAL.Domain:EXN).
+
+Some of these concepts may be helpful:
+
+- [Lazy evaluation](https://en.wikipedia.org/wiki/Lazy_evaluation)
+- Sieving (for instance [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
+- Primality by [trial division](https://en.wikipedia.org/wiki/Trial_divisio://en.wikipedia.org/wiki/Trial_division)
+
+
+## Loading your exercise implementation in PolyML
+
+```
+$ poly --use {exercise}.sml
+```
+
+Or:
+
+```
+$ poly
+> use "{exercise}.sml";
+```
+
+**Note:** You have to replace {exercise}.
+
 ## Running the tests
 
-Even though there are multiple implementations, we encourage to use Poly/ML.
-
 ```
-$ poly -q < test_{ exercise }.sml
+$ poly -q --use test.sml
 ```
 
-If you want to start an interactive session:
-```
-$ poly --use test_{ exercise }.sml
-```
+## Feedback, Issues, Pull Requests
+
+The [exercism/sml](https://github.com/exercism/sml) repository on
+GitHub is the home for all of the Standard ML exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue. We'll do our best to help you!
 
 ## Source
 

--- a/exercises/nth-prime/example.sml
+++ b/exercises/nth-prime/example.sml
@@ -1,47 +1,29 @@
-exception EmptyList
-datatype 'a lazylist = Nil | Cons of ('a * (unit -> 'a lazylist));
-fun next s = let
-    fun next' Nil = raise EmptyList
-      | next' (Cons(a,f)) = f()
-in
-    next' s
-end ;
+fun nthPrime n =
+  let
+    fun isPrime n =
+      if n = 2
+      then true
+      else if n < 2 orelse n mod 2 = 0
+           then false
+           else
+             let
+               fun loop i =
+                 if i * i > n
+                 then true
+                 else if n mod i = 0
+                      then false
+                      else loop (i + 2)
+             in
+               loop 3
+             end
 
-fun hd s = let
-    fun hd' Nil = raise EmptyList
-      | hd' (Cons(a, _)) = a
-in
-    hd' s
-end ;
-
-fun allPrimes n = let
-    fun isPrime n = let
-        fun factors n = let
-            fun factors' 0 acc = acc
-              | factors' c acc = if (n mod c) = 0
-                                 then factors' (c-1) (c :: acc)
-                                 else factors' (c-1) acc
-        in
-            factors' (n div 2) []
-        end
-    in
-        (List.length (factors n)) = 1
-    end
-
-    fun nextPrime n = let
-        val nextN = if (n mod 2) = 0 then n + 1 else n + 2
-    in
-        if isPrime nextN then nextN else nextPrime nextN
-    end
-
-in
-    Cons(n, fn () => (allPrimes (nextPrime n)))
-end ;
-
-fun nthPrime n = let
-    fun nthPrime' 0 s = hd s
-      | nthPrime' n s = nthPrime' (n-1) (next s)
-in
-    if n <= 0 then raise Domain
-    else nthPrime' (n-1) (allPrimes 2)
-end ;
+    fun loop i m =
+      case (i = n, isPrime m) of
+        (true , true)  => m
+      | (false, true)  => loop (i + 1) (m + 1)
+      | (_    , _   )  => loop i (m + 1)
+  in
+    if n < 1
+    then raise Domain
+    else loop 1 2
+  end

--- a/exercises/nth-prime/nth-prime.sml
+++ b/exercises/nth-prime/nth-prime.sml
@@ -1,2 +1,2 @@
 fun nthPrime (n: int): int =
-  raise Fail "'nthPrime' has not been implemented"
+  raise Fail "'prime' is not implemented"

--- a/exercises/nth-prime/test.sml
+++ b/exercises/nth-prime/test.sml
@@ -1,71 +1,27 @@
+(* version 1.0.0 *)
+
+use "testlib.sml";
 use "nth-prime.sml";
 
-val test_cases = [
-  {
-    description = "The first prime is 2",
-    input = 1,
-    expected = 2
-  },
-  {
-    description = "The second prime is 3",
-    input = 2,
-    expected = 3
-  },
-  {
-    description = "The ninth prime is 23",
-    input = 9,
-    expected = 23
-  },
-  {
-    description = "The one-hundredth prime is 541",
-    input = 100,
-    expected = 541
-  },
-  {
-    description = "The three-thousand and first prime is 27457",
-    input = 3001,
-    expected = 27457
-  }
-];
+infixr |>
+fun x |> f = f x
 
-val error_test_cases = [
-  {
-    description = "The 0th prime is not defined",
-    input = 0,
-    expected = Domain
-  },
-  {
-    description = "The -1st prime is not defined",
-    input = ~1,
-    expected = Domain
-  }
-];
+val testsuite =
+  describe "nth-prime" [
+    test "first prime"
+      (fn _ => nthPrime 1 |> Expect.equalTo 2),
 
-fun run_tests _ [] = []
-  | run_tests f (x :: xs) =
-      let
-        fun aux { description, is_correct } =
-          let
-            val expl = description ^ ": " ^
-              (if is_correct then "PASSED" else "FAILED") ^ "\n"
-          in
-            (print (expl); is_correct)
-          end
-      in
-        (aux x) :: run_tests f xs
-      end
+    test "second prime"
+      (fn _ => nthPrime 2 |> Expect.equalTo 3),
 
-fun evaluateGoodTestCase f { description, input, expected } =
-  { description = description, is_correct = (f input) = expected }
+    test "sixth prime"
+      (fn _ => nthPrime 6 |> Expect.equalTo 13),
 
-fun evaluateErrorTestCase f { description, input, expected } =
-  { description = description, is_correct = (f input handle expected => 1) = 1 }
+    test "big prime"
+      (fn _ => nthPrime 10001 |> Expect.equalTo 104743),
 
-val testResults = run_tests nthPrime (List.map (evaluateGoodTestCase nthPrime) test_cases)
-  @ run_tests nthPrime (List.map (evaluateErrorTestCase nthPrime) error_test_cases);
-val passedTests = List.filter (fn x => x) testResults;
-val failedTests = List.filter (fn x => not x) testResults;
+    test "there is no zeroth prime"
+      (fn _ => (fn _ => nthPrime 0) |> Expect.error Domain)
+  ]
 
-if (List.length testResults) = (List.length passedTests)
-then (print "ALL TESTS PASSED")
-else (print (Int.toString (List.length failedTests) ^ " TEST(S) FAILED"));
+val _ = Test.run testsuite

--- a/exercises/nth-prime/testlib.sml
+++ b/exercises/nth-prime/testlib.sml
@@ -1,0 +1,159 @@
+structure Expect =
+struct
+  datatype expectation = Pass | Fail of string * string
+
+  local
+    fun failEq b a =
+      Fail ("Expected: " ^ b, "Got: " ^ a)
+    
+    fun failExn b a =
+      Fail ("Expected: " ^ b, "Raised: " ^ a)
+
+    fun exnName (e: exn): string = General.exnName e
+  in
+    fun truthy a =
+      if a
+      then Pass
+      else failEq "true" "false"
+
+    fun falsy a =
+      if a
+      then failEq "false" "true"
+      else Pass
+
+    fun equalTo b a = 
+      if a = b
+      then Pass
+      else failEq (PolyML.makestring b) (PolyML.makestring a)
+
+    fun nearTo b a =
+      if Real.== (a, b)
+      then Pass
+      else failEq (Real.toString b) (Real.toString a)
+
+    fun anyError f =
+      (
+        f ();
+        failExn "an exception" "Nothing"
+      ) handle _ => Pass
+
+    fun error e f =
+      (
+        f ();
+        failExn (exnName e) "Nothing"
+      ) handle e' => if exnMessage e' = exnMessage e
+                     then Pass
+                     else failExn (exnMessage e) (exnMessage e')
+  end
+end
+
+structure TermColor =
+struct
+  datatype color = Red | Green | Yellow | Normal
+
+  fun f Red    = "\027[31m"
+    | f Green  = "\027[32m"
+    | f Yellow = "\027[33m"
+    | f Normal = "\027[0m"
+
+  fun colorize color s = (f color) ^ s ^ (f Normal)
+
+  val redit = colorize Red
+
+  val greenit = colorize Green
+
+  val yellowit = colorize Yellow
+end
+
+structure Test =
+struct
+  datatype testnode = TestGroup of string * testnode list
+                    | Test of string * (unit -> Expect.expectation)
+
+  local
+    datatype evaluation = Success of string
+                        | Failure of string * string * string
+                        | Error of string * string
+
+    fun indent n s = (implode (List.tabulate (n, fn _ => #" "))) ^ s
+
+    fun fmt indentlvl ev =
+      let
+        val check = TermColor.greenit "\226\156\148 " (* ✔ *)
+        val cross = TermColor.redit "\226\156\150 "   (* ✖ *)
+        val indentlvl = indentlvl * 2
+      in
+      case ev of
+        Success descr => indent indentlvl (check ^ descr)
+      | Failure (descr, exp, got) =>
+          String.concatWith "\n" [indent indentlvl (cross ^ descr),
+                                  indent (indentlvl + 2) exp,
+                                  indent (indentlvl + 2) got]
+      | Error (descr, reason) =>
+          String.concatWith "\n" [indent indentlvl (cross ^ descr),
+                                  indent (indentlvl + 2) (TermColor.redit reason)]
+      end
+
+    fun eval (TestGroup _) = raise Fail "Only a 'Test' can be evaluated"
+      | eval (Test (descr, thunk)) =
+          (
+            case thunk () of
+              Expect.Pass   => ((1, 0, 0), Success descr)
+            | Expect.Fail (s, s') => ((0, 1, 0), Failure (descr, s, s'))
+          )
+          handle e => ((0, 0, 1), Error (descr, "Unexpected error: " ^ exnMessage e))
+
+    fun flatten depth testnode =
+      let
+        fun sum (x, y, z) (a, b, c) = (x + a, y + b, z + c)
+
+        fun aux (t, (counter, acc)) =
+          let
+            val (counter', texts) = flatten (depth + 1) t
+          in
+            (sum counter' counter, texts :: acc)
+          end
+      in
+        case testnode of
+          TestGroup (descr, ts) =>
+            let
+              val (counter, texts) = foldr aux ((0, 0, 0), []) ts
+            in
+              (counter, (indent (depth * 2) descr) :: List.concat texts)
+            end
+        | Test _ =>
+            let
+              val (counter, evaluation) = eval testnode
+            in
+              (counter, [fmt depth evaluation])
+            end
+      end
+    
+    fun println s = print (s ^ "\n")
+  in
+    fun run suite =
+      let
+        val ((succeeded, failed, errored), texts) = flatten 0 suite
+
+        val summary = String.concatWith ", " [
+          TermColor.greenit ((Int.toString succeeded) ^ " passed"),
+          TermColor.redit ((Int.toString failed) ^ " failed"),
+          TermColor.redit ((Int.toString errored) ^ " errored"),
+          (Int.toString (succeeded + failed + errored)) ^ " total"
+        ]
+        
+        val status = if failed = 0 andalso errored = 0
+                     then OS.Process.success
+                     else OS.Process.failure
+
+      in
+        List.app println texts;
+        println "";
+        println ("Tests: " ^ summary);
+        OS.Process.exit status
+      end
+  end
+end
+
+fun describe description tests = Test.TestGroup (description, tests)
+fun test description thunk = Test.Test (description, thunk)


### PR DESCRIPTION
Changes:
   flatten-array: update test, README, example & stub

   - add HINTS.md

   generator: add extra options

   - add --{test, stub, example}-only
   - add --force option to bypass type mismatch
   - update README with these changes

   nth-prime: update test, readme, stub & example

   - add HINTS.md
   - fix example.sml