### PR TITLE
nth-prime: fix broken hints link

### DIFF
--- a/exercises/nth-prime/.meta/hints.md
+++ b/exercises/nth-prime/.meta/hints.md
@@ -6,4 +6,4 @@ Some of these concepts may be helpful:
 
 - [Lazy evaluation](https://en.wikipedia.org/wiki/Lazy_evaluation)
 - Sieving (for instance [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
-- Primality by [trial division](https://en.wikipedia.org/wiki/Trial_divisio://en.wikipedia.org/wiki/Trial_division)
+- Primality by [trial division](https://en.wikipedia.org/wiki/Trial_division)


### PR DESCRIPTION
Fixes broken link to trial division wiki page.

(Looks like I fixed this in the README ages ago, but didn't realise that the part of the README this is fetched from was HINTS!)