### PR TITLE
prime-factors: Change stub name and signature, bump test suite

### DIFF
--- a/exercises/prime-factors/example.sml
+++ b/exercises/prime-factors/example.sml
@@ -1,4 +1,4 @@
-fun factors n =
+fun primeFactors n =
   let
     fun aux prime n =
       if prime * prime > n

--- a/exercises/prime-factors/prime-factors.sml
+++ b/exercises/prime-factors/prime-factors.sml
@@ -1,2 +1,2 @@
-fun factors (input: int): int list =
-  raise Fail "'factors' is not implemented"
+fun primeFactors n =
+  raise Fail "'primeFactors' is not implemented"

--- a/exercises/prime-factors/test.sml
+++ b/exercises/prime-factors/test.sml
@@ -1,4 +1,4 @@
-(* version 1.0.0 *)
+(* version 1.1.0 *)
 
 use "prime-factors.sml";
 use "testlib.sml";
@@ -10,25 +10,25 @@ val testsuite =
   describe "prime-factors" [
     describe "returns prime factors for the given input number" [
       test "no factors"
-        (fn _ => factors (1) |> Expect.equalTo []),
+        (fn _ => primeFactors (1) |> Expect.equalTo []),
 
       test "prime number"
-        (fn _ => factors (2) |> Expect.equalTo [2]),
+        (fn _ => primeFactors (2) |> Expect.equalTo [2]),
 
       test "square of a prime"
-        (fn _ => factors (9) |> Expect.equalTo [3, 3]),
+        (fn _ => primeFactors (9) |> Expect.equalTo [3, 3]),
 
       test "cube of a prime"
-        (fn _ => factors (8) |> Expect.equalTo [2, 2, 2]),
+        (fn _ => primeFactors (8) |> Expect.equalTo [2, 2, 2]),
 
       test "product of primes and non-primes"
-        (fn _ => factors (12) |> Expect.equalTo [2, 2, 3]),
+        (fn _ => primeFactors (12) |> Expect.equalTo [2, 2, 3]),
 
       test "product of primes"
-        (fn _ => factors (901255) |> Expect.equalTo [5, 17, 23, 461]),
+        (fn _ => primeFactors (901255) |> Expect.equalTo [5, 17, 23, 461]),
 
       test "factors include a large prime"
-        (fn _ => factors (93819012551) |> Expect.equalTo [11, 9539, 894119])
+        (fn _ => primeFactors (93819012551) |> Expect.equalTo [11, 9539, 894119])
     ]
   ]
 


### PR DESCRIPTION
- Change stub from `factors` to `primeFactors`. This better enables solutions that aim to first generate factors and then filter primes.
- The type signature is removed from the stub cf. discussion in the commit 1649138e450fcd9f8cf6a639503460978826b566.
- Bump test to 1.1.0: exercism/problem-specifications#1154 (no-op)