### PR TITLE
bin/fetch-configlet: Make HTTP header detection case-insensitive

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -26,7 +26,10 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
+VERSION="$(curl --head --silent $LATEST | perl -nE 's/\R//g; /^Location:/i && print [split/\//]->[-1]')"
+URL="https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz"
+
+echo "VERSION = $VERSION"
+echo "URL = $URL"
 
 curl -s --location $URL | tar xz -C bin/


### PR DESCRIPTION
Currently bin/fetch-configlet fails because of case sensitivity.
    
The awk script matches only uppercase headers, and for some reason, the
curl command has lately been returning the Location header in lowercase:
    
    location: https://github.com/exercism/configlet/releases/tag/v3.9.2
    
This change makes detection of latest configlet version independent of the casing of the HTTP headers returned by curl. Perl was used in this change rather than awk.