### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Every exercise must have at least these files:
 - `test.sml`: Test suite
 - `testlib.sml` Test helper
 
-#### `testlib.sml`
+### `testlib.sml`
 
 This helper has this structures:
 

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [Standard ML (SML)](https://en.wikipedia.org/wiki/Standard_ml) is one of the two main dialects of the ML programming
 language. [ML](https://en.wikipedia.org/wiki/ML_programming_language) was the first strong statically typed language,
 developed in the early 1970s at the University of Edinburgh. 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 ## Recommended Learning Resources
 
 Exercism provides exercises and feedback but ML can be difficult to jump into for those learning SML for the first time. 

--- a/exercises/practice/bob/.meta/description.md
+++ b/exercises/practice/bob/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Bob is a lackadaisical teenager. In conversation, his responses are very limited.
 
 Bob answers 'Sure.' if you ask him a question.

--- a/exercises/practice/flatten-array/.docs/instructions.append.md
+++ b/exercises/practice/flatten-array/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You can think of this data structure as a [`Rose Tree`](https://en.wikipedia.org/wiki/Rose_tree). You are given a data type `'a tree` that represents this data structure.
 

--- a/exercises/practice/nth-prime/.docs/instructions.append.md
+++ b/exercises/practice/nth-prime/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 If the argument is not less than `1` raise the exception [`Domain`](http://sml-family.org/Basis/general.html#SIG:GENERAL.Domain:EXN).
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
