### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "c9940926-0d32-49dc-be67-3ad84f955b62",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Standard ML locally",
+      "blurb": "Learn how to install Standard ML locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "c2d09890-f131-4abe-b1c0-b3c12f7e37bc",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Standard ML",
+      "blurb": "An overview of how to get started from scratch with Standard ML"
+    },
+    {
+      "uuid": "2a2f5288-f3e1-4b09-b786-efc968e7b280",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Standard ML track",
+      "blurb": "Learn how to test your Standard ML exercises on Exercism"
+    },
+    {
+      "uuid": "28ffa9a7-d8cc-4a56-b77c-6fcbaab3a5ad",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Standard ML resources",
+      "blurb": "A collection of useful resources to help you master Standard ML"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
