### PR TITLE
Fix Makefile and bin/generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,11 @@ debug:
 	@git diff-tree --name-status -r --no-commit-id --diff-filter=R -M $(COMMIT_RANGE)
 	@echo ---------------
 
-# FIXME GHA target is broken and this gets unnoticed by GitHub Actions.
 gha:
 	@$(MAKE) -s debug
 	$(eval tests := $(shell \
 		git diff-tree --name-only -r --diff-filter=AM $(COMMIT_RANGE) | \
-		perl -n -e '/exercises\/practice/([a-z-_]+)\/.+\.sml/ && print "test-$$1\n"' | uniq))
+		perl -n -e '/exercises\/practice\/([a-z-_]+)\/.+\.sml/ && print "test-$$1\n"' | uniq))
 	$(if $(tests), @echo Tests: $(tests), @echo 'Nothing to test.')
 	$(if $(tests), @$(MAKE) -s $(tests))
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-dirs := $(wildcard exercises/*)
+dirs := $(wildcard exercises/practice/*)
 all-tests := $(addprefix test-, $(notdir $(dirs)))
 
 COMMIT_RANGE := HEAD
@@ -21,6 +21,7 @@ debug:
 	@git diff-tree --name-status -r --no-commit-id --diff-filter=R -M $(COMMIT_RANGE)
 	@echo ---------------
 
+# FIXME GHA target is broken and this gets unnoticed by GitHub Actions.
 gha:
 	@$(MAKE) -s debug
 	$(eval tests := $(shell \
@@ -32,13 +33,13 @@ gha:
 test-%:
 	$(eval exercise := $(patsubst test-%, %, $@))
 	@echo
-	@ls ./exercises/practice/$(exercise)/README.md > /dev/null
+	@ls ./exercises/practice/$(exercise)/.docs/instructions.md > /dev/null
 	@# check stub type
 	@cd ./exercises/practice/$(exercise) && \
 		poly -q --use test | grep 'error: Type error' | \
 		wc -l | xargs -I @ expr @ = 0 > /dev/null || \
 		{ echo '$(exercise).sml is faulty'; exit 1; }
-	@cd ./exercises/practice/$(exercise) && cat test.sml | sed 's/$(exercise).sml/.meta/example.sml/' | poly -q
+	@cd ./exercises/practice/$(exercise) && cat test.sml | sed 's/$(exercise).sml/.meta\/example.sml/' | poly -q
 	@echo
 
 .PHONY: test

--- a/bin/generate
+++ b/bin/generate
@@ -217,9 +217,6 @@ def generate_test_content(data, signature, force=False):
         return acc
 
     return '\n'.join([
-        # FIXME version is missing in data
-        '(* version %s *)' % 'UNKNOWN', #data['version'],
-        '',
         'use "testlib.sml";',
         'use "%s.sml";' % data['exercise'],
         '',

--- a/bin/generate
+++ b/bin/generate
@@ -139,8 +139,6 @@ def extract_signatures(data, force=False):
             else:
                 # assumes there's at least one test with non "nullish" vars
                 fn = camelize(case.get('property', exercise))
-                if fn == "isPaired": # FIXME how to treat this renaming correctly?
-                    fn = "isBalanced"
                 if sml_type(case['expected'], force=force) == 'exn':
                     continue
                 args = get_fn_args(case)
@@ -194,8 +192,6 @@ def generate_test_content(data, signature, force=False):
         if 'property' not in  case:
             print('WARNING: property not found using exercise name as function name')
         fn = camelize(case.get('property', exercise))
-        if fn == "isPaired": # FIXME how to treat this renaming correctly?
-            fn = "isBalanced"
         expected = case['expected']
         args = get_fn_args(case)
         return '\n'.join((

--- a/bin/generate
+++ b/bin/generate
@@ -100,11 +100,10 @@ def sml_value(value, smltype='', force=False):
 
 
 def get_fn_args(case):
-    reserved_keys = {'property', 'expected', 'description', 'comments'}
+    case_input = case["input"]
     return OrderedDict(
-        (k, case[k])
-        for k in sorted(case.keys())
-        if k not in reserved_keys
+        (k, case_input[k])
+        for k in sorted(case_input.keys())
     )
 
 
@@ -140,6 +139,8 @@ def extract_signatures(data, force=False):
             else:
                 # assumes there's at least one test with non "nullish" vars
                 fn = camelize(case.get('property', exercise))
+                if fn == "isPaired": # FIXME how to treat this renaming correctly?
+                    fn = "isBalanced"
                 if sml_type(case['expected'], force=force) == 'exn':
                     continue
                 args = get_fn_args(case)
@@ -157,7 +158,8 @@ def extract_signatures(data, force=False):
 def expectation(signature, fn, args, expected, force=False):
     tmpl = '(fn _ => %s |> Expect.%s)'
     output = sml_value(expected, signature['output'], force=force)
-    invocation = '%s (%s)' % (
+    invocation_tmpl = '%s %s' if len(args) == 1 else '%s (%s)'
+    invocation = invocation_tmpl % (
         fn,
         ', '.join((
             sml_value(val, signature['args'][arg], force=force)
@@ -192,6 +194,8 @@ def generate_test_content(data, signature, force=False):
         if 'property' not in  case:
             print('WARNING: property not found using exercise name as function name')
         fn = camelize(case.get('property', exercise))
+        if fn == "isPaired": # FIXME how to treat this renaming correctly?
+            fn = "isBalanced"
         expected = case['expected']
         args = get_fn_args(case)
         return '\n'.join((
@@ -213,7 +217,8 @@ def generate_test_content(data, signature, force=False):
         return acc
 
     return '\n'.join([
-        '(* version %s *)' % data['version'],
+        # FIXME version is missing in data
+        '(* version %s *)' % 'UNKNOWN', #data['version'],
         '',
         'use "testlib.sml";',
         'use "%s.sml";' % data['exercise'],
@@ -260,7 +265,7 @@ FLAGS = TEST | STUB | EXAMPLE
 
 def generate(exercise, flags, force=False):
     root = Path(__file__).parent.parent.absolute()
-    path = root / 'exercises' / exercise
+    path = root / 'exercises' / 'practice' / exercise
 
     if not path.exists():
         path.mkdir()


### PR DESCRIPTION
Fix of Errors which made `Makefile` and `bin/generate` unusable.

Some errors are just syntax errors, others are due to the fact that the companion-repo `exercism/problem-specifications` evolved without the above mentioned files being updated.