### PR TITLE
Remove master from workflow ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: sml / ci
 on:
   pull_request:
   push:
-    branches: [master, main]
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Since all exercism repos moved from master to main, we don't need to check for master in the workflow-scripts anymore. This change was suggested by the reviewer in my previous PR: https://github.com/exercism/sml/pull/199#discussion_r869166876.