### PR TITLE
nearTo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ structure Expect:
     val error: exn -> (unit -> 'a) -> expectation
     datatype expectation = Fail of string * string | Pass
     val falsy: bool -> expectation
-    val nearTo: real -> real -> expectation
+    val nearTo: real -> real -> real -> expectation
     val truthy: bool -> expectation
   end
 structure Test:
@@ -76,7 +76,7 @@ val testsuite =
       (fn _ => bar () |> Expect.truthy),
     
     test "something that baz does"
-      (fn _ => baz (123) |> Expect.nearTo 123.10),
+      (fn _ => baz (123) |> Expect.nearTo 0.001 123.10),
     
     test "an exception from 'qux'"
       (fn _ => (fn _ => qux (0, 0))) |> Expect.error QuxError),

--- a/bin/generate
+++ b/bin/generate
@@ -204,7 +204,7 @@ def expectation(signature, fn, args, expected, force=False):
     if signature['output'] == 'real':
         return tmpl % (
             invocation,
-            'nearTo %s' % output
+            'nearTo 0.001 %s' % output
         )
     return tmpl % (
         invocation,

--- a/exercises/practice/accumulate/testlib.sml
+++ b/exercises/practice/accumulate/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/all-your-base/testlib.sml
+++ b/exercises/practice/all-your-base/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/allergies/testlib.sml
+++ b/exercises/practice/allergies/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/anagram/testlib.sml
+++ b/exercises/practice/anagram/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/atbash-cipher/testlib.sml
+++ b/exercises/practice/atbash-cipher/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/binary/testlib.sml
+++ b/exercises/practice/binary/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/bob/testlib.sml
+++ b/exercises/practice/bob/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/collatz-conjecture/testlib.sml
+++ b/exercises/practice/collatz-conjecture/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/diamond/testlib.sml
+++ b/exercises/practice/diamond/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/difference-of-squares/testlib.sml
+++ b/exercises/practice/difference-of-squares/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/flatten-array/testlib.sml
+++ b/exercises/practice/flatten-array/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/hamming/testlib.sml
+++ b/exercises/practice/hamming/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/hello-world/testlib.sml
+++ b/exercises/practice/hello-world/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/leap/testlib.sml
+++ b/exercises/practice/leap/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/list-ops/testlib.sml
+++ b/exercises/practice/list-ops/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/matching-brackets/testlib.sml
+++ b/exercises/practice/matching-brackets/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/nth-prime/testlib.sml
+++ b/exercises/practice/nth-prime/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/pangram/testlib.sml
+++ b/exercises/practice/pangram/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/perfect-numbers/testlib.sml
+++ b/exercises/practice/perfect-numbers/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/phone-number/testlib.sml
+++ b/exercises/practice/phone-number/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/pig-latin/testlib.sml
+++ b/exercises/practice/pig-latin/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/prime-factors/testlib.sml
+++ b/exercises/practice/prime-factors/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/raindrops/testlib.sml
+++ b/exercises/practice/raindrops/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/rna-transcription/testlib.sml
+++ b/exercises/practice/rna-transcription/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/roman-numerals/testlib.sml
+++ b/exercises/practice/roman-numerals/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/sum-of-multiples/testlib.sml
+++ b/exercises/practice/sum-of-multiples/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/exercises/practice/two-fer/testlib.sml
+++ b/exercises/practice/two-fer/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (

--- a/lib/testlib.sml
+++ b/lib/testlib.sml
@@ -26,10 +26,11 @@ struct
       then Pass
       else failEq (PolyML.makestring b) (PolyML.makestring a)
 
-    fun nearTo b a =
-      if Real.== (a, b)
+    fun nearTo delta b a =
+      if Real.abs (a - b) <= delta * Real.abs a orelse
+         Real.abs (a - b) <= delta * Real.abs b
       then Pass
-      else failEq (Real.toString b) (Real.toString a)
+      else failEq (Real.toString b ^ " +/- " ^ Real.toString delta) (Real.toString a)
 
     fun anyError f =
       (


### PR DESCRIPTION
I made a script to redeploy `lib/testlib.sml` to all exercises.  After testing that script I realized that `Space Age` is using an improved version of the test function `nearTo` which includes a delta.  This version of `nearTo` looks like it is more coherent to me, so I deployed it to all exercises.

~I isolated my redeploy script in its own commit.  Please read the commit message.  Basically, I figured out how to use `poly` in a shebang.  If we want to use the Makefile instead then I think there are some questions about where sml code should live that is neither a library nor an executable.  Anyway, if using unixisms is contentious, then we can change it.  If reviewers would prefer that that script gets submitted as its own PR that seems reasonable to me.  I include the updated testlib here, because having this script in the project while not having all the testlib.sml files the same seems unsound to me, but I can be flexible.~

The aforementioned script has been pulled out and refactored #206 .  This branch has been rebased on `main`.  I still think this PR should merge after #206, but they shouldn't break each other, so I don't think the order really matters.

As shown in the commit messages `nearTo` was only used by the space age exercise, and it appeared twice in the `README.md` and once in `bin/generate`.  Updating the "blessed" testlib.sml, the edits to the peripheral files, and the deployment of the new testlib were all isolated into their own commit.  They probably want rebasing, but I figured it is fine for now.  
