### PR TITLE
Quickfix for failing github action `ci`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        sml-version: [5.8]
+        sml-version: [5.9]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The github action `ci` fails with the following error during the build of poly-ml v5.8:

```
In file included from /usr/include/pthread.h:33,
                 from locking.h:44,
                 from processes.h:38,
                 from sighandler.cpp:103:
sighandler.cpp:557:6: error: missing binary operator before token "("
  557 | #if (PTHREAD_STACK_MIN < 4096)
      |      ^~~~~~~~~~~~~~~~~
make[3]: *** [Makefile:761: sighandler.lo] Error 1
make[3]: Leaving directory '/home/runner/work/sml/sml/polyml-5.8/libpolyml'
make[2]: *** [Makefile:801: all-recursive] Error 1
make[2]: Leaving directory '/home/runner/work/sml/sml/polyml-5.8/libpolyml'
make[1]: *** [Makefile:722: all-recursive] Error 1
make[1]: Leaving directory '/home/runner/work/sml/sml/polyml-5.8'
make: *** [Makefile:487: all] Error 2
```

The reason that this fails now and not earlier is very likely connected to the fact that `ubuntu-latest` recently changed from `ubuntu-20.4` to `ubuntu-22.4`.

**I fixed the error** while still using `ubuntu-latest` by switching to poly-ml v5.9. The [release notes of v5.9](https://github.com/polyml/polyml/releases/tag/v5.9) explicitly mention `Fix for systems where PTHREAD_STACK_MIN is a function rather than a constant.` which solves the error.
