### PR TITLE
Swap Uranus and Neptune in exercise `space-age`

### DIFF
--- a/exercises/practice/space-age/.meta/example.sml
+++ b/exercises/practice/space-age/.meta/example.sml
@@ -1,5 +1,5 @@
 datatype planet = Mercury | Venus | Earth | Mars
-                | Jupiter | Saturn | Neptune | Uranus
+                | Jupiter | Saturn | Uranus | Neptune
 
 fun earthYears seconds = seconds / 31557600.0
 

--- a/exercises/practice/space-age/space-age.sml
+++ b/exercises/practice/space-age/space-age.sml
@@ -1,5 +1,5 @@
 datatype planet = Mercury | Venus | Earth | Mars
-                | Jupiter | Saturn | Neptune | Uranus
+                | Jupiter | Saturn | Uranus | Neptune
 
 fun age_on planet seconds =
   raise Fail "'age_on' is not implemented"


### PR DESCRIPTION
Due too https://github.com/exercism/sml/issues/214 it is a minor inconvenience that Uranus and Neptune are in the "wrong" order in the template presented to the students. I fixed this.

- [x] rebase after https://github.com/exercism/sml/pull/218 is merged.