### PR TITLE
Sync collatz-conjecture exercise

### DIFF
--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -23,6 +23,16 @@ description = "large number of even and odd steps"
 
 [7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
 description = "zero is an error"
+include = false
+
+[2187673d-77d6-4543-975e-66df6c50e2da]
+description = "zero is an error"
+reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
 
 [c6c795bf-a288-45e9-86a1-841359ad426d]
 description = "negative value is an error"
+include = false
+
+[ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
+description = "negative value is an error"
+reimplements = "c6c795bf-a288-45e9-86a1-841359ad426d"


### PR DESCRIPTION
Unlike many tracks, the Standard ML implementation for the collatz-conjecture exercise does not use the error strings - it uses `NONE` instead.

The error text in `problem-specifications` recently changed. As the `test.sml` for this exercise does not contain error text, no `test.sml` changes are needed at this time.

