### PR TITLE
Sync space-age exercise test metadata

### DIFF
--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -32,3 +32,7 @@ description = "age on Uranus"
 
 [80096d30-a0d4-4449-903e-a381178355d8]
 description = "age on Neptune"
+
+[57b96e2a-1178-40b7-b34d-f3c9c34e4bf4]
+description = "invalid planet causes error"
+include = false


### PR DESCRIPTION
We exclude the new test as the type system prevents non-planets from being passed as planets.