### PR TITLE
Forego concurrency exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -595,6 +595,10 @@
       }
     ]
   },
+  "foregone": [
+    "bank-account",
+    "parallel-letter-frequency"
+  ],
   "concepts": [],
   "key_features": [
     {


### PR DESCRIPTION
We declare the following exercises as foregone:
- bank-account
- parallel-letter-frequency

These exercises require concurrency, but Standard ML does not support
this.
