### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/flatten-array/.docs/instructions.append.md
+++ b/exercises/practice/flatten-array/.docs/instructions.append.md
@@ -1,8 +1,12 @@
-# Hints
+# Instructions append
 
-You can think of this data structure as a [`Rose Tree`](https://en.wikipedia.org/wiki/Rose_tree). You are given a data type `'a tree` that represents this data structure.
+## Hints
+
+You can think of this data structure as a [`Rose Tree`](https://en.wikipedia.org/wiki/Rose_tree).
+You are given a data type `'a tree` that represents this data structure.
 
 **Notes**
+
 - For this exercise `Empty` represents `null`
 - The nested list is represented by `List [...]`.
 - The input example is represented by `List [Elem 1, List [Elem 2, Elem 3, Empty, Elem 4], List [Empty], Elem 5]`

--- a/exercises/practice/grade-school/.docs/instructions.append.md
+++ b/exercises/practice/grade-school/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 To complete this exercise you need to implement the struct by defining the data type `school` and implementing the functions:
 
 - newSchool

--- a/exercises/practice/nth-prime/.docs/instructions.append.md
+++ b/exercises/practice/nth-prime/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 If the argument is less than `1`, return [`NONE`](https://smlfamily.github.io/Basis/option.html#SIG:OPTION.option:TY:SPEC).
 

--- a/exercises/practice/split-second-stopwatch/.docs/instructions.append.md
+++ b/exercises/practice/split-second-stopwatch/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 To complete this exercise you need to define the data type `stopwatch`, and implement the functions:
 
 - newStopwatch
@@ -13,5 +15,4 @@ To complete this exercise you need to define the data type `stopwatch`, and impl
 - total
 - previousLaps
 
-You will find a dummy type definition already in place,
-but it is up to you to define the functions and create a meaningful data type.
+You will find a dummy type definition already in place, but it is up to you to define the functions and create a meaningful data type.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.